### PR TITLE
Switch tests to use VerificationTest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+  agent { docker { image 'wolfram-docker-11.3.0' } }
+  options { skipDefaultCheckout true }
+  stages {
+    stage('Run tests') {
+      steps {
+        dir('GeneralRelativityTensors') {
+          checkout scm
+          sh 'Tests/AllTests.wls'
+          junit 'TestReport.xml'
+        }
+      }
+    }
+  }
+}

--- a/Tests/AllTests.wls
+++ b/Tests/AllTests.wls
@@ -1,0 +1,65 @@
+#!/usr/bin/env wolframscript
+
+Print["Mathematica Version: ", $Version];
+
+withinRoundoff[a_, b_] :=
+  (* Ignore the last N machine digits *)
+  Block[{Internal`$SameQTolerance = 4},
+    SameQ[a,b]];
+
+PrependTo[$Path, FileNameDrop[ExpandFileName[First[$ScriptCommandLine]],-3]];
+
+<< GeneralRelativityTensors`
+
+testFiles = FileNames["*.wlt", DirectoryName[ExpandFileName[First[$ScriptCommandLine]]]];
+
+reports = TestReport /@ testFiles;
+
+numTestsSucceeded = Total[#["TestsSucceededCount"] & /@ reports];
+numTestsFailed    = Total[#["TestsFailedCount"]& /@ reports];
+numTests          = numTestsSucceeded + numTestsFailed;
+
+time = QuantityMagnitude[Total[(#["TimeElapsed"] & /@ reports)], "Seconds"];
+
+(* Generate XML for a single test result *)
+testResultXML[result_] :=
+  XMLElement["testcase",
+    {"name" -> ToString[result["TestID"]], 
+     "time" -> ToString[QuantityMagnitude[result["AbsoluteTimeUsed"], "Seconds"]]}, 
+    Switch[result["Outcome"],
+      "Failure",
+        {XMLElement["failure", {}, {XMLObject["CDATASection"][
+          "Input: " <> ToString[result["Input"], InputForm] <> "\n" <>
+          "Expected output: " <> ToString[result["ExpectedOutput"], InputForm] <> "\n" <>
+          "Actual output: " <> ToString[result["ActualOutput"], InputForm]]}]},
+      "MessagesFailure",
+        {XMLElement["failure", {}, {XMLObject["CDATASection"][
+          "Expected Messages: " <> ToString[result["ExpectedMessages"], InputForm] <> "\n" <>
+          "Actual Messages: " <> ToString[result["ActualMessages"], InputForm]]}]},
+      "Error",
+          {XMLElement["failure", {}, {XMLObject["CDATASection"]["Error"]}]},
+      "Success",
+          {}
+    ]
+];
+
+testsuiteXML[report_] :=
+  XMLElement["testsuite",
+    {"name" -> report["Title"],
+     "tests" -> ToString[report["TestsSucceededCount"] + report["TestsFailedCount"]],
+     "failures" -> ToString[report["TestsFailedCount"]],
+     "time" -> ToString[QuantityMagnitude[report["TimeElapsed"], "Seconds"]]},
+    Map[testResultXML, Values[report["TestResults"]]]];
+
+xml = XMLObject["Document"][{XMLObject["Declaration"]["Version" -> "1.0",  "Encoding" -> "UTF-8"]}, 
+  XMLElement[
+    "testsuites",
+    {"id" -> DateString["ISODateTime"],
+     "name" -> "GeneralRelativityTensors Tests",
+     "time" -> ToString[time],
+     "tests" -> ToString[numTests], 
+     "failures" -> ToString[numTestsFailed]}, 
+     testsuiteXML /@ reports
+     ], {}];
+
+Export["TestReport.xml", xml, "XML"]

--- a/Tests/AllTests.wls
+++ b/Tests/AllTests.wls
@@ -44,12 +44,25 @@ testResultXML[result_] :=
 ];
 
 testsuiteXML[report_] :=
-  XMLElement["testsuite",
-    {"name" -> report["Title"],
-     "tests" -> ToString[report["TestsSucceededCount"] + report["TestsFailedCount"]],
-     "failures" -> ToString[report["TestsFailedCount"]],
-     "time" -> ToString[QuantityMagnitude[report["TimeElapsed"], "Seconds"]]},
-    Map[testResultXML, Values[report["TestResults"]]]];
+ Module[{xml},
+  If[MatchQ[report["TestResults"], <| {"Event", "Fatal"} -> __ |>],
+    xml = XMLElement["testsuite",
+      {"name" -> report["Title"],
+       "tests" -> "1",
+       "failures" -> "1",
+       "time" -> ToString[QuantityMagnitude[report["TimeElapsed"], "Seconds"]]},
+      {XMLElement["testcase", {"name" -> "Loading test file"},
+                  {XMLElement["failure", {}, {XMLObject["CDATASection"]["Error reading file"]}]}]}
+      ];,
+    xml = XMLElement["testsuite",
+      {"name" -> report["Title"],
+       "tests" -> ToString[report["TestsSucceededCount"] + report["TestsFailedCount"]],
+       "failures" -> ToString[report["TestsFailedCount"]],
+       "time" -> ToString[QuantityMagnitude[report["TimeElapsed"], "Seconds"]]},
+        Map[testResultXML, Values[report["TestResults"]]]];
+  ];
+  xml
+];
 
 xml = XMLObject["Document"][{XMLObject["Declaration"]["Version" -> "1.0",  "Encoding" -> "UTF-8"]}, 
   XMLElement[

--- a/Tests/CommonTensors.wlt
+++ b/Tests/CommonTensors.wlt
@@ -5,7 +5,7 @@ gRNC = ToTensorFieldOnCurve[gRN, c1];
 einRN = EinsteinTensor[gRN];
 einRNC = EinsteinTensor[gRNC];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@ChristoffelSymbol[gRN],
 	{{{0, (-Q^2 + M r)/(r (Q^2 + r (-2 M + r))), 0, 0}, {(-Q^2 + M r)/(
    r (Q^2 + r (-2 M + r))), 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 
@@ -19,7 +19,7 @@ Test[
 	TestID->"ChristoffelSymbol1"	
 ];
 
-Test[Simplify@TensorValues@ChristoffelSymbol[gRNC]
+VerificationTest[Simplify@TensorValues@ChristoffelSymbol[gRNC]
 	,
 	{{{0, -(((1 + e Cos[\[Chi]])^2 (-M^2 p + Q^2 + e Q^2 Cos[\[Chi]]))/(
     M p (M^2 (-2 + p) p + Q^2 - 2 e (M^2 p - Q^2) Cos[\[Chi]] + 
@@ -47,7 +47,7 @@ Test[Simplify@TensorValues@ChristoffelSymbol[gRNC]
 	TestID->"ChristoffelSymbol2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@RiemannTensor[gRN] - {{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, (
     3 Q^2 - 2 M r)/r^4, 0, 0}, {(-3 Q^2 + 2 M r)/r^4, 0, 0, 0}, {0, 0,
      0, 0}, {0, 0, 0, 0}}, {{0, 
@@ -101,7 +101,7 @@ Test[
 	TestID->"RiemannTensor1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@RiemannTensor[gRNC] - {{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 
     0}}, {{0, ((1 + e Cos[\[Chi]])^3 (-2 M^2 p + 3 Q^2 + 
        3 e Q^2 Cos[\[Chi]]))/(M^4 p^4), 0, 
@@ -202,7 +202,7 @@ Test[
 	TestID->"RiemannTensor2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@RicciTensor[gRN]-
 	{{(Q^4 + Q^2 r (-2 M + r))/r^6, 0, 0, 
   0}, {0, -(Q^2/(r^2 (Q^2 + r (-2 M + r)))), 0, 0}, {0, 0, Q^2/r^2, 
@@ -211,7 +211,7 @@ Test[
 	TestID->"RicciTensor1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@RicciTensor[gRNC],
 	{{(Q^2 (1 + e Cos[\[Chi]])^4 (M^2 (-2 + p) p + Q^2 - 
      2 e (M^2 p - Q^2) Cos[\[Chi]] + e^2 Q^2 Cos[\[Chi]]^2))/(
@@ -224,19 +224,19 @@ Test[
 	TestID->"RicciTensor2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@RicciScalar[gRN],
 	0,
 	TestID->"RicciScalar1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@RicciScalar[gRNC],
 	0,
 	TestID->"RicciScalar2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@EinsteinTensor[gRN],
 	{{(Q^2 (Q^2 + r (-2 M + r)))/r^6, 0, 0, 
   0}, {0, -(Q^2/(r^2 (Q^2 + r (-2 M + r)))), 0, 0}, {0, 0, Q^2/r^2, 
@@ -244,7 +244,7 @@ Test[
 	TestID->"EinsteinTensor1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@EinsteinTensor[gRNC],
 	{{(Q^2 (1 + e Cos[\[Chi]])^4 (M^2 (-2 + p) p + Q^2 - 
      2 e (M^2 p - Q^2) Cos[\[Chi]] + e^2 Q^2 Cos[\[Chi]]^2))/(
@@ -257,7 +257,7 @@ Test[
 	TestID->"EinsteinTensor2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@WeylTensor[gRN]-
 	{{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, (
     2 (Q^2 - M r))/r^4, 0, 0}, {(2 (-Q^2 + M r))/r^4, 0, 0, 0}, {0, 0,
@@ -312,7 +312,7 @@ Test[
 	TestID->"WeylTensor1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@WeylTensor[gRNC]-
 	{{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, (
     2 (1 + e Cos[\[Chi]])^3 (-M^2 p + Q^2 + e Q^2 Cos[\[Chi]]))/(
@@ -430,25 +430,25 @@ FRNC = FieldStrengthTensor[ARNC];
 seRN = MaxwellStressEnergyTensor[FRN];
 seRNC = MaxwellStressEnergyTensor[FRNC];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@ARN,
 	{Q/r, 0, 0, 0},
 	TestID->"MaxwellPotential1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@ARNC,
 	{(Q + e Q Cos[\[Chi]])/(M p), 0, 0, 0},
 	TestID->"MaxwellPotential2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@FRN,
 	{{0, -(Q/r^2), 0, 0}, {Q/r^2, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 	TestID->"FieldStrengthTensor1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@FRNC,
 	{{0, -((Q (1 + e Cos[\[Chi]])^2)/(M^2 p^2)), 0, 0}, {(
   Q (1 + e Cos[\[Chi]])^2)/(M^2 p^2), 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 
@@ -456,7 +456,7 @@ Test[
 	TestID->"FieldStrengthTensor2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@seRN,
 	{{Q^2/(8 \[Pi] r^2 (Q^2 + r (-2 M + r))), 0, 0, 
   0}, {0, -((Q^2 (Q^2 + r (-2 M + r)))/(8 \[Pi] r^6)), 0, 0}, {0, 0, 
@@ -465,7 +465,7 @@ Test[
 	TestID->"MaxwellStressEnergyTensor1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@seRNC,
 	{{(Q^2 (1 + e Cos[\[Chi]])^4)/(
   8 M^2 p^2 \[Pi] (M^2 (-2 + p) p + Q^2 - 
@@ -479,25 +479,25 @@ Test[
 	TestID->"MaxwellStressEnergyTensor2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@MergeTensors[EinsteinTensor[gRN][-\[Alpha], -\[Beta]] - 8 \[Pi] seRN[-\[Alpha], -\[Beta]]],
 	{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 	TestID->"EinsteinEquations1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@MergeTensors[EinsteinTensor[gRNC][-\[Alpha], -\[Beta]] - 8 \[Pi] seRNC[-\[Alpha], -\[Beta]]],
 	{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 	TestID->"EinsteinEquations2"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@KretschmannScalar[gRN],
 	(8 (7 Q^4 - 12 M Q^2 r + 6 M^2 r^2))/r^8,
 	TestID->"KretschmannScalar1"	
 ];
 
-Test[
+VerificationTest[
 	Simplify@TensorValues@KretschmannScalar[gRNC],
 	(8 (1 + e Cos[\[Chi]])^6 (6 M^4 p^2 - 12 M^2 p Q^2 + 7 Q^4 + 
    2 e Q^2 (-6 M^2 p + 7 Q^2) Cos[\[Chi]] + 

--- a/Tests/GeneralRelativityTensors.mt
+++ b/Tests/GeneralRelativityTensors.mt
@@ -1,9 +1,0 @@
-TestSuite[
-	{
-		"TensorCaching.mt",
-		"CommonTensors.mt",
-		"TensorCurves.mt",
-		"TensorCreation.mt",
-		"TensorManipulation.mt",
-		"TensorDerivatives.mt"
-		}]

--- a/Tests/TensorCaching.wlt
+++ b/Tests/TensorCaching.wlt
@@ -1,13 +1,13 @@
 gK = ToMetric["Kerr"];
 
 
-Test[
+VerificationTest[
 	$CacheTensorValues,
 	False,
 	TestID->"$CacheTensorValues"	
 ];
 
-Test[
+VerificationTest[
 	CachedTensorValues[gK],
 	{},
 	TestID->"CachedTensorValues1"	
@@ -16,7 +16,7 @@ Test[
 $CacheTensorValues = True;
 TensorValues[gK];
 
-Test[
+VerificationTest[
 	CachedTensorValues[gK],
 	{{"KerrMetric", {"Down", 
     "Down"}} -> {{(-a^2 + 2 M r - r^2 + a^2 Sin[\[Theta]]^2)/(
@@ -33,7 +33,7 @@ Test[
 
 $CacheTensorValues = False;
 
-Test[
+VerificationTest[
 	CachedTensorValues[gK],
 	{{"KerrMetric", {"Down", 
     "Down"}} -> {{(-a^2 + 2 M r - r^2 + a^2 Sin[\[Theta]]^2)/(
@@ -50,7 +50,7 @@ Test[
 
 ClearCachedTensorValues[gK];
 
-Test[
+VerificationTest[
 	CachedTensorValues[gK],
 	{},
 	TestID->"ClearCachedTensorValues"

--- a/Tests/TensorCreation.wlt
+++ b/Tests/TensorCreation.wlt
@@ -1,6 +1,6 @@
 gK = ToMetric["Kerr"];
 
-Test[
+VerificationTest[
 	TensorValues[gK],
 	{{(-a^2 + 2 M r - r^2 + a^2 Sin[\[Theta]]^2)/(r^2 + a^2 Cos[\[Theta]]^2), 0, 0, 
 		-((2 a M r Sin[\[Theta]]^2)/(r^2 + a^2 Cos[\[Theta]]^2))}, 
@@ -11,7 +11,7 @@ Test[
 	TestID->"ToMetric1"	
 ]
 
-Test[
+VerificationTest[
 	TensorValues@ToTensor["t1", gK, {g[t], h[r], j[r, \[Theta]], k[r, \[Phi]]}],
 	{g[t], h[r], j[r, \[Theta]], k[r, \[Phi]]},
 	TestID->"ToTensor1"	

--- a/Tests/TensorCurves.wlt
+++ b/Tests/TensorCurves.wlt
@@ -3,13 +3,13 @@ c1 = ToCurve["x1", gK, {t[\[Chi]], (p M)/(1 + e Cos[\[Chi]]), \[Pi]/2, \[Phi][\[
 gKC = ToTensorFieldOnCurve[gK, c1];
 gKC2 = ToTensorOnCurve["gCurve", c1, TensorValues[gKC], {-\[Alpha], -\[Beta]}];
 
-Test[
+VerificationTest[
 	TensorValues[c1],
 	{t[\[Chi]], (p M)/(1 + e Cos[\[Chi]]), \[Pi]/2, \[Phi][\[Chi]]},
 	TestID->"Curve1"	
 ]
 
-Test[
+VerificationTest[
 	RawTensorValues[gKC]
 	,
 	{{(-a^2 + 2 M r - r^2 + a^2 Sin[\[Theta]]^2)/(
@@ -24,7 +24,7 @@ Test[
 	TestID->"Curve-RawTensorValues"	
 ]
 
-Test[
+VerificationTest[
 	TensorValues[gKC],
 	{{((1 + e Cos[\[Chi]])^2 (-((M^2 p^2)/(1 + e Cos[\[Chi]])^2) + (
      2 M^2 p)/(1 + e Cos[\[Chi]])))/(M^2 p^2), 0, 
@@ -40,49 +40,49 @@ Test[
 	TestID->"Curve-TensorValues"	
 ]
 
-Test[
+VerificationTest[
 	Curve[c1],
 	c1,
 	TestID->"Curve-Curve1"	
 ]
 
-Test[
+VerificationTest[
 	Curve[gKC],
 	c1,
 	TestID->"Curve-Curve2"	
 ]
 
-Test[
+VerificationTest[
 	Curve[gK],
 	Undefined,
 	TestID->"Curve-Curve3"	
 ]
 
-Test[
+VerificationTest[
 	CurveQ[c1],
 	True,
 	TestID->"Curve-CurveQ1"	
 ]
 
-Test[
+VerificationTest[
 	CurveQ[gKC],
 	False,
 	TestID->"Curve-CurveQ2"	
 ]
 
-Test[
+VerificationTest[
 	OnCurveQ[c1],
 	True,
 	TestID->"Curve-OnCurveQ1"	
 ]
 
-Test[
+VerificationTest[
 	OnCurveQ[gKC],
 	False,
 	TestID->"Curve-OnCurveQ2"	
 ]
 
-Test[
+VerificationTest[
 	OnCurveQ[gKC2],
 	True,
 	TestID->"Curve-OnCurveQ3"	

--- a/Tests/TensorDerivatives.wlt
+++ b/Tests/TensorDerivatives.wlt
@@ -5,7 +5,7 @@ ricTRN = RicciTensor[gRN];
 ricSRN = RicciScalar[gRN];
 uS = FourVelocityVector["SchwarzschildGeneric"];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues[D[gRN[\[Alpha], \[Beta]], -\[Alpha]]]-{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{(
    2 r (-Q^2 + M r))/(Q^2 + r (-2 M + r))^2, 0, 0, 0}, {0, (
    2 (-Q^2 + M r))/r^3, 0, 0}, {0, 0, -(2/r^3), 0}, {0, 0, 
@@ -20,7 +20,7 @@ Test[
 	TestID->"Tensor-D1"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues[D[uS, \[Tau]]]
 	-
 	{-((2 M \[ScriptCapitalE] Derivative[1][r][\[Tau]])/(-2 M + 
@@ -34,7 +34,7 @@ r[\[Tau]] + M r[\[Tau]]^2) Derivative[1][r][\[Tau]])/(
 	TestID->"Tensor-D2"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@MergeTensors@CovariantD[gRN,-\[Gamma]]],
 	{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, 0, 0, 
    0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, 0, 0, 0}, {0, 
@@ -43,7 +43,7 @@ Test[
 	TestID->"Tensor-CovariantD1"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@MergeTensors@CovariantD[uS,uS]-
 	{(2 M \[ScriptCapitalE] (Sqrt[\[ScriptCapitalE]^2 - ((-2 M + 
         r[\[Tau]]) (\[ScriptCapitalL]^2 + r[\[Tau]]^2))/r[\[Tau]]^3] -
@@ -63,7 +63,7 @@ Test[
 	TestID->"Tensor-CovariantD2"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues[MergeTensors[BianchiIdentities[gRN,0]]]],
 	{{{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, 0, 
      0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, 0, 0, 
@@ -131,7 +131,7 @@ Test[
 	TestID->"Bianchi0"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues[MergeTensors[BianchiIdentities[gRN,1]]]],
 	{{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, 0, 0, 
    0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {{0, 0, 0, 0}, {0, 
@@ -140,7 +140,7 @@ Test[
 	TestID->"Bianchi1"
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues[MergeTensors[BianchiIdentities[gRN,2]]]],
 	{0, 0, 0, 0},
 	TestID->"Bianchi2"

--- a/Tests/TensorManipulation.wlt
+++ b/Tests/TensorManipulation.wlt
@@ -5,26 +5,26 @@ ricTRN = RicciTensor[gRN];
 ricSRN = RicciScalar[gRN];
 uS = FourVelocityVector["SchwarzschildGeneric"];
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@ShiftIndices[gK,{\[Alpha], \[Beta]}]-TensorValues@InverseMetric[gK]],
 	{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 	TestID->"ShiftIndices1"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues[gK[\[Alpha], -\[Beta]]]],
 	{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}},
 	TestID->"ShiftIndices2"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[Component[gK,{-t,-t}]-(-((a^2 - 2 M r + r^2 - a^2 Sin[\[Theta]]^2)/(
  r^2 + a^2 Cos[\[Theta]]^2)))],
 	0,
 	TestID->"Component1"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[gK[t,t] - (-((a^4 + 2 r^4 + a^2 r (2 M + 3 r) + 
   a^2 (a^2 + r (-2 M + r)) Cos[2 \[Theta]])/((a^2 + 
     r (-2 M + r)) (a^2 + 2 r^2 + a^2 Cos[2 \[Theta]]))))],
@@ -32,13 +32,13 @@ Test[
 	TestID->"Component2"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@ContractIndices[gK[\[Alpha], -\[Alpha]]]],
 	4,
 	TestID->"ContractIndices"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@MultiplyTensors[uS[\[Alpha]], uS[\[Beta]]]
 	-
 	{{\[ScriptCapitalE]^2/(1 - (2 M)/
@@ -64,19 +64,19 @@ M + r[\[Tau]]) (\[ScriptCapitalL]^2 + r[\[Tau]]^2))/r[\[Tau]]^3])/
 	TestID->"MultiplyTensors"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@AddTensors[gK, gK]-TensorValues@MultiplyTensorScalar[2, gK]],
 	{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
 	TestID->"MultiplyTensorScalar-AddTensors"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[2 TensorValues@uS - TensorValues@MultiplyTensorScalar[2, uS]],
 	{0, 0, 0, 0},
 	TestID->"MultiplyTensorScalar"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@MergeTensors[ricTRN[-\[Alpha], -\[Beta]] - gRN[-\[Alpha], -\[Beta]] ricSRN/2]
 	-
 	{{(Q^2 (Q^2 + r (-2 M + r)))/r^6, 0, 0, 
@@ -86,7 +86,7 @@ Test[
 	TestID->"MergeTensors1"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@MergeTensors[uS[\[Alpha]] uS[\[Beta]]]
 	-
 	{{\[ScriptCapitalE]^2/(1 - (2 M)/
@@ -112,7 +112,7 @@ M + r[\[Tau]]) (\[ScriptCapitalL]^2 + r[\[Tau]]^2))/r[\[Tau]]^3])/
 	TestID->"MergeTensors2"	
 ]
 
-Test[
+VerificationTest[
 	Simplify[TensorValues@
    ReorderTensorIndices[
     rieRN[-\[Alpha], -\[Beta], -\[Gamma], -\[Delta]], {2, 1, 3, 4}] + 


### PR DESCRIPTION
Mathematica now has built in support for unit tests through the VerificationTest function. These commits update the unit tests to use this new functionality and uses them to automate running of unit tests with jenkins. The results of the tests are shown on GitHub (see, for example, the tick beside commit b4ced20 in this pull request) are also appear directly on the toolkit Jenkins server at https://build.bhptoolkit.org.